### PR TITLE
adding "make dev-shell" to enter development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+
+dev-shell:
+	docker-compose run --rm --service-ports dev /bin/bash
+
+clean:
+	docker-compose down
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # leket2
 Leket App 2
+
+# Setting up a development environment
+
+The development environment can be configured using Docker. To drop into a shell with all the environment already set, just do:
+
+```sh
+# make dev-shell
+```
+
+You can then do `yarn start`, `yarn test` etc.
+
+To cleanup the Docker container, do `make clean`.

--- a/config/docker/dev
+++ b/config/docker/dev
@@ -1,0 +1,5 @@
+FROM node:7.7.3
+
+# install Yarn
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.22.0
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+dev:
+  dockerfile: config/docker/dev
+  build: .
+  volumes:
+    - ./:${PWD}
+  working_dir: ${PWD}
+  ports:
+    - "3000:3000"


### PR DESCRIPTION
The development environment can be configured using Docker. To drop into a shell with all the environment already set, just do:

```sh
# make dev-shell
```

You can then do `yarn start`, `yarn test` etc.

To cleanup the Docker container, do `make clean`.