### PR TITLE
Upgrade to node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "7"
+  - "8.1.4"
 script: 
 - yarn build

--- a/config/docker/dev
+++ b/config/docker/dev
@@ -1,4 +1,4 @@
-FROM node:7.7.3
+FROM node:8.1.4
 
 # install Yarn
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.22.0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "7.9.0",
+    "node": "8.1.4",
     "npm": "4.2.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "css-loader": "^0.28.0",
     "jest": "^19.0.2",
     "json-loader": "^0.5.4",
-    "node-sass": "^4.5.2",
+    "node-sass": "^4.5.3",
     "nodemon": "^1.11.0",
     "postcss-loader": "^1.3.3",
     "react-dom": "^15.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,13 +1677,13 @@ dateformat@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
 
-debug@2.6.1, debug@^2.1.1, debug@^2.2.0, debug@^2.3.0, debug@^2.4.5:
+debug@2.6.1, debug@^2.1.1, debug@^2.2.0, debug@^2.3.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
     ms "0.7.2"
 
-debug@2.6.3:
+debug@2.6.3, debug@^2.4.5:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
@@ -4269,9 +4269,9 @@ node-pre-gyp@^0.6.29:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-sass@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.2.tgz#4012fa2bd129b1d6365117e88d9da0500d99da64"
+node-sass@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.3.tgz#d09c9d1179641239d1b97ffc6231fdcec53e1568"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
Upgrade to Node 8.
This vulnerability: https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/ 
is a good occasion to upgrade to node 8.